### PR TITLE
Update functions.jl

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -435,11 +435,7 @@ function string(x::BigRational; base::Integer = 10, pad::Integer = 1)
                               string(denominator(x); base=base, pad=pad) * ')')
 end
 function show(io::IO, x::BigRational)
-    if get(io, :typeinfo, Any) == BigRational
-        print(io, numerator(x), "//", denominator(x))
-    else
-        print(io, string(x))
-    end
+    print(io, numerator(x), "//", denominator(x))
 end
 
 function read(io::IO, ::Type{BigRational})


### PR DESCRIPTION
The "show" method did not function properly in Julia 1.10.5; the if clause should have been unnecessary anyhow, because Julia allows overloading and x is explicitly specified to be a BigRational.